### PR TITLE
[Issue-3] Create Icon Component

### DIFF
--- a/ArcMoney.xcodeproj/project.pbxproj
+++ b/ArcMoney.xcodeproj/project.pbxproj
@@ -40,14 +40,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		846B73492CEF62F1002C9CED /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				84FE89502CD11BC00041D2ED /* Colors.swift */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
 		BE13CA162CC6983E0015BB46 = {
 			isa = PBXGroup;
 			children = (
@@ -67,7 +59,6 @@
 		BE13CA212CC6983E0015BB46 /* ArcMoney */ = {
 			isa = PBXGroup;
 			children = (
-				846B73492CEF62F1002C9CED /* Utils */,
 				C226B58D2CD275E900F4BA44 /* Utils */,
 				C27F64632CCFEB2200F75606 /* Design System */,
 				BE13CA222CC6983E0015BB46 /* ArcMoneyApp.swift */,

--- a/ArcMoney.xcodeproj/project.pbxproj
+++ b/ArcMoney.xcodeproj/project.pbxproj
@@ -7,20 +7,26 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		84FE89512CD11BC00041D2ED /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FE89502CD11BC00041D2ED /* Colors.swift */; };
 		BE13CA232CC6983E0015BB46 /* ArcMoneyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13CA222CC6983E0015BB46 /* ArcMoneyApp.swift */; };
 		BE13CA252CC6983E0015BB46 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13CA242CC6983E0015BB46 /* ContentView.swift */; };
 		BE13CA272CC698400015BB46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BE13CA262CC698400015BB46 /* Assets.xcassets */; };
 		BE13CA2A2CC698400015BB46 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BE13CA292CC698400015BB46 /* Preview Assets.xcassets */; };
+		C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B58B2CD275E900F4BA44 /* ArcMoneyIcon.swift */; };
+		C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B58C2CD275E900F4BA44 /* Colors.swift */; };
+		C226B5912CD27F1100F4BA44 /* ArcMoneySize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B5902CD27F1100F4BA44 /* ArcMoneySize.swift */; };
+		C27F64652CCFEB3A00F75606 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27F64642CCFEB3A00F75606 /* IconView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		84FE89502CD11BC00041D2ED /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		BE13CA1F2CC6983E0015BB46 /* ArcMoney.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArcMoney.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE13CA222CC6983E0015BB46 /* ArcMoneyApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneyApp.swift; sourceTree = "<group>"; };
 		BE13CA242CC6983E0015BB46 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BE13CA262CC698400015BB46 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BE13CA292CC698400015BB46 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C226B58B2CD275E900F4BA44 /* ArcMoneyIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneyIcon.swift; sourceTree = "<group>"; };
+		C226B58C2CD275E900F4BA44 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		C226B5902CD27F1100F4BA44 /* ArcMoneySize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneySize.swift; sourceTree = "<group>"; };
+		C27F64642CCFEB3A00F75606 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +68,8 @@
 			isa = PBXGroup;
 			children = (
 				846B73492CEF62F1002C9CED /* Utils */,
+				C226B58D2CD275E900F4BA44 /* Utils */,
+				C27F64632CCFEB2200F75606 /* Design System */,
 				BE13CA222CC6983E0015BB46 /* ArcMoneyApp.swift */,
 				BE13CA242CC6983E0015BB46 /* ContentView.swift */,
 				BE13CA262CC698400015BB46 /* Assets.xcassets */,
@@ -76,6 +84,24 @@
 				BE13CA292CC698400015BB46 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		C226B58D2CD275E900F4BA44 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C226B5902CD27F1100F4BA44 /* ArcMoneySize.swift */,
+				C226B58B2CD275E900F4BA44 /* ArcMoneyIcon.swift */,
+				C226B58C2CD275E900F4BA44 /* Colors.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		C27F64632CCFEB2200F75606 /* Design System */ = {
+			isa = PBXGroup;
+			children = (
+				C27F64642CCFEB3A00F75606 /* IconView.swift */,
+			);
+			path = "Design System";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -148,8 +174,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C226B5912CD27F1100F4BA44 /* ArcMoneySize.swift in Sources */,
+				C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */,
+				C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */,
+				C27F64652CCFEB3A00F75606 /* IconView.swift in Sources */,
 				BE13CA252CC6983E0015BB46 /* ContentView.swift in Sources */,
-				84FE89512CD11BC00041D2ED /* Colors.swift in Sources */,
 				BE13CA232CC6983E0015BB46 /* ArcMoneyApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ArcMoney/Design System/IconView.swift
+++ b/ArcMoney/Design System/IconView.swift
@@ -1,0 +1,60 @@
+//
+//  IconView.swift
+//  ArcMoney
+//
+//  Created by Matheus Vaccaro on 10/28/24.
+//
+
+import SwiftUI
+
+// MARK: - IconView
+
+struct IconView: View {
+    
+    // MARK: Internal Properties
+    
+    let icon: ArcMoneyIcon
+    let size: ArcMoneySize
+    let color: Color
+    
+    // MARK: Lifecycle
+    
+    init(icon: ArcMoneyIcon, size: ArcMoneySize = .medium, color: Color = .primary) {
+        self.icon = icon
+        self.size = size
+        self.color = color
+    }
+    
+    // MARK: Body
+    
+    var body: some View {
+        icon.image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(
+                width: size.rawValue,
+                height: size.rawValue)
+            .foregroundStyle(color)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack {
+        HStack {
+            Text("Small Icon:")
+            IconView(icon: .salary, size: .small)
+        }
+        
+        HStack {
+            Text("Medium Icon:")
+            IconView(icon: .salary, size: .medium)
+        }
+        
+        HStack {
+            Text("Large Icon:")
+            IconView(icon: .salary, size: .large)
+        }
+    }
+}

--- a/ArcMoney/Design System/IconView.swift
+++ b/ArcMoney/Design System/IconView.swift
@@ -44,17 +44,32 @@ struct IconView: View {
     VStack {
         HStack {
             Text("Small Icon:")
+            
             IconView(icon: .salary, size: .small)
+            IconView(icon: .salary, size: .small, color: .light)
+            IconView(icon: .salary, size: .small, color: .dark)
+            IconView(icon: .salary, size: .small, color: .primary)
+            IconView(icon: .salary, size: .small, color: .secondary)
         }
         
         HStack {
             Text("Medium Icon:")
+            
             IconView(icon: .salary, size: .medium)
+            IconView(icon: .salary, size: .medium, color: .light)
+            IconView(icon: .salary, size: .medium, color: .dark)
+            IconView(icon: .salary, size: .medium, color: .primary)
+            IconView(icon: .salary, size: .medium, color: .secondary)
         }
         
         HStack {
             Text("Large Icon:")
+            
             IconView(icon: .salary, size: .large)
+            IconView(icon: .salary, size: .large, color: .light)
+            IconView(icon: .salary, size: .large, color: .dark)
+            IconView(icon: .salary, size: .large, color: .primary)
+            IconView(icon: .salary, size: .large, color: .secondary)
         }
     }
 }

--- a/ArcMoney/Utils/ArcMoneyIcon.swift
+++ b/ArcMoney/Utils/ArcMoneyIcon.swift
@@ -1,0 +1,24 @@
+//
+//  ArcMoneyIcon.swift
+//  ArcMoney
+//
+//  Created by Matheus Vaccaro on 10/28/24.
+//
+
+enum ArcMoneyIcon: String {
+    case shopping = "cart.fill"
+    case food = "fork-knife"
+    case entertainment = "popcorn.fill"
+    case transportation = "bus"
+    case education = "graduationcap.fill"
+    case healthcare = "stethoscope"
+    case salary = "dollarsign"
+    case investment = "chart.line.uptrend.xyaxis"
+    case notification = "bell"
+    case goBack = "arrow.left"
+    case homeUnselected = "house"
+    case homeSelected = "house.fill"
+    case settingsUnselected = "gearshape"
+    case settingsSelected = "gearshape.fill"
+    case dropdownArrow = "chevron.down"
+}

--- a/ArcMoney/Utils/ArcMoneyIcon.swift
+++ b/ArcMoney/Utils/ArcMoneyIcon.swift
@@ -5,7 +5,14 @@
 //  Created by Matheus Vaccaro on 10/28/24.
 //
 
+import SwiftUI
+
+// MARK: - ArcMoneyIcon
+
 enum ArcMoneyIcon: String {
+    
+    // MARK: Cases
+    
     case shopping = "cart.fill"
     case food = "fork-knife"
     case entertainment = "popcorn.fill"
@@ -21,4 +28,10 @@ enum ArcMoneyIcon: String {
     case settingsUnselected = "gearshape"
     case settingsSelected = "gearshape.fill"
     case dropdownArrow = "chevron.down"
+    
+    // MARK: Internal Properties
+    
+    var image: Image {
+        Image(systemName: self.rawValue)
+    }
 }

--- a/ArcMoney/Utils/ArcMoneySize.swift
+++ b/ArcMoney/Utils/ArcMoneySize.swift
@@ -1,0 +1,19 @@
+//
+//  ArcMoneySize.swift
+//  ArcMoney
+//
+//  Created by Matheus Vaccaro on 10/30/24.
+//
+
+import Foundation
+
+// MARK: - ArcMoneySize
+
+enum ArcMoneySize: CGFloat {
+    
+    // MARK: Cases
+    
+    case small = 18
+    case medium = 24
+    case large = 38
+}


### PR DESCRIPTION
# ArcMoney Pull Request

## Issue
This Pull Request closes #3 

## What changed?
This PR adds 3 new files to the project:
- `ArcMoneySize`: An enum containing common sizes to be used by the components of the Design System.
- `ArcMoneyIcon`: An enum containing all supported icons.
- `IconView`: The 1st reusable component of the Design System. Represents a reusable Icon which can be configured by using the 2 enums defined above and the Color extensions defined by Jamile.

> IMPORTANT: This PR depends on #10.

## Testing
`IconView` should be able to be used inside any SwiftUI view, like the preview below:

![Screenshot 2024-11-04 at 5 45 00 PM](https://github.com/user-attachments/assets/869ff3f3-a3ca-40db-b585-022beddbc637)

## Evidence
![Screenshot 2024-11-04 at 5 38 38 PM](https://github.com/user-attachments/assets/5438b42c-f341-46ff-89f2-f7f85ea2f500)