### PR TITLE
[Issue-16] Add File Header Customization

### DIFF
--- a/ArcMoney.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/ArcMoney.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string> ___PROJECTNAME___</string>
+</dict>
+</plist>


### PR DESCRIPTION
# ArcMoney Pull Request

## Issue
This Pull Request closes #16 

## What changed?
This PR adds a file named `IDETemplateMacros.plist` to allow us to customize the Header of a file created by Xcode.

**Important:** The header override does not allow us to completely remove the header text. If we leave the `FILEHEADER` key with an empty value in the `.plist` we still get a single "// ".

To go around this issue, I arbitrarily updated the header to display the project's name instead. If needed, we can update this value to display something else 🙌 

> Additional Info: Since our `.gitignore` ignores changes made it `.xcodeproj`, we had to manually add it in Git by calling:
> `git add -f ArcMoney.xcodeproj/project.xcworkspace/xcshareddata/IDETemplateMacros.plist`

> IMPORTANT: After we discuss about this update, a rebase will be performed and all existing files will be updated to have their Headers removed 🤘 

## Evidence
Before | After
--- | ---
![Screenshot 2024-11-25 at 6 25 48 PM](https://github.com/user-attachments/assets/0e86b1fe-2184-450d-93ad-0bfa71e5dd35) | ![Screenshot 2024-11-25 at 6 54 23 PM](https://github.com/user-attachments/assets/04356ffe-df6d-4195-a2f7-2b3086ba8a89)
