### PR TITLE
[Issue-8] Add DropdownView Component

### DIFF
--- a/ArcMoney.xcodeproj/project.pbxproj
+++ b/ArcMoney.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		C2E02ADF2CF575B8005F8AB6 /* BackgroundedIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E02ADE2CF575B8005F8AB6 /* BackgroundedIconView.swift */; };
 		C2E02AE22CF57816005F8AB6 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E02AE12CF57812005F8AB6 /* View+Extensions.swift */; };
 		C2E02AE42CF57A5F005F8AB6 /* ArcMoneyCornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E02AE32CF57A5D005F8AB6 /* ArcMoneyCornerRadius.swift */; };
+		C2E6A1282D386C690084E39F /* DropdownRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E6A1272D386C680084E39F /* DropdownRowView.swift */; };
+		C2F839352D2459D50075324E /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F839342D2459D30075324E /* DropdownView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +48,8 @@
 		C2E02ADE2CF575B8005F8AB6 /* BackgroundedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundedIconView.swift; sourceTree = "<group>"; };
 		C2E02AE12CF57812005F8AB6 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		C2E02AE32CF57A5D005F8AB6 /* ArcMoneyCornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneyCornerRadius.swift; sourceTree = "<group>"; };
+		C2E6A1272D386C680084E39F /* DropdownRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownRowView.swift; sourceTree = "<group>"; };
+		C2F839342D2459D30075324E /* DropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +67,7 @@
 			isa = PBXGroup;
 			children = (
 				C2E02ADE2CF575B8005F8AB6 /* BackgroundedIconView.swift */,
+				C2E6A1262D386C300084E39F /* DropdownView */,
 				C27F64642CCFEB3A00F75606 /* IconView.swift */,
 				844315FA2CF4B4D30073B708 /* Labels.swift */,
 			);
@@ -156,6 +161,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		C2E6A1262D386C300084E39F /* DropdownView */ = {
+			isa = PBXGroup;
+			children = (
+				C2E6A1272D386C680084E39F /* DropdownRowView.swift */,
+				C2F839342D2459D30075324E /* DropdownView.swift */,
+			);
+			path = DropdownView;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -229,12 +243,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C226B5912CD27F1100F4BA44 /* ArcMoneySize.swift in Sources */,
+				C2E6A1282D386C690084E39F /* DropdownRowView.swift in Sources */,
 				C2E02AE22CF57816005F8AB6 /* View+Extensions.swift in Sources */,
 				C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */,
 				C2E02ADF2CF575B8005F8AB6 /* BackgroundedIconView.swift in Sources */,
 				C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */,
 				C201FAEE2D2F222D00592551 /* VStack+Extensions.swift in Sources */,
 				C201FAEC2D2F21BF00592551 /* HStack+Extensions.swift in Sources */,
+				C2F839352D2459D50075324E /* DropdownView.swift in Sources */,
 				C27F64652CCFEB3A00F75606 /* IconView.swift in Sources */,
 				BE13CA252CC6983E0015BB46 /* ContentView.swift in Sources */,
 				BE13CA232CC6983E0015BB46 /* ArcMoneyApp.swift in Sources */,

--- a/ArcMoney.xcodeproj/project.pbxproj
+++ b/ArcMoney.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		BE13CA252CC6983E0015BB46 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE13CA242CC6983E0015BB46 /* ContentView.swift */; };
 		BE13CA272CC698400015BB46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BE13CA262CC698400015BB46 /* Assets.xcassets */; };
 		BE13CA2A2CC698400015BB46 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BE13CA292CC698400015BB46 /* Preview Assets.xcassets */; };
+		C201FAEC2D2F21BF00592551 /* HStack+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C201FAEB2D2F21BA00592551 /* HStack+Extensions.swift */; };
+		C201FAEE2D2F222D00592551 /* VStack+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C201FAED2D2F222A00592551 /* VStack+Extensions.swift */; };
 		C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B58B2CD275E900F4BA44 /* ArcMoneyIcon.swift */; };
 		C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B58C2CD275E900F4BA44 /* Colors.swift */; };
 		C226B5912CD27F1100F4BA44 /* ArcMoneySize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C226B5902CD27F1100F4BA44 /* ArcMoneySize.swift */; };
@@ -34,6 +36,8 @@
 		BE13CA242CC6983E0015BB46 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BE13CA262CC698400015BB46 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BE13CA292CC698400015BB46 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		C201FAEB2D2F21BA00592551 /* HStack+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HStack+Extensions.swift"; sourceTree = "<group>"; };
+		C201FAED2D2F222A00592551 /* VStack+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VStack+Extensions.swift"; sourceTree = "<group>"; };
 		C226B58B2CD275E900F4BA44 /* ArcMoneyIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneyIcon.swift; sourceTree = "<group>"; };
 		C226B58C2CD275E900F4BA44 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		C226B5902CD27F1100F4BA44 /* ArcMoneySize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneySize.swift; sourceTree = "<group>"; };
@@ -145,7 +149,9 @@
 		C2E02AE02CF577D0005F8AB6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				C201FAEB2D2F21BA00592551 /* HStack+Extensions.swift */,
 				C2E02AE12CF57812005F8AB6 /* View+Extensions.swift */,
+				C201FAED2D2F222A00592551 /* VStack+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -227,6 +233,8 @@
 				C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */,
 				C2E02ADF2CF575B8005F8AB6 /* BackgroundedIconView.swift in Sources */,
 				C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */,
+				C201FAEE2D2F222D00592551 /* VStack+Extensions.swift in Sources */,
+				C201FAEC2D2F21BF00592551 /* HStack+Extensions.swift in Sources */,
 				C27F64652CCFEB3A00F75606 /* IconView.swift in Sources */,
 				BE13CA252CC6983E0015BB46 /* ContentView.swift in Sources */,
 				BE13CA232CC6983E0015BB46 /* ArcMoneyApp.swift in Sources */,

--- a/ArcMoney.xcodeproj/project.pbxproj
+++ b/ArcMoney.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		C2E02AE22CF57816005F8AB6 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E02AE12CF57812005F8AB6 /* View+Extensions.swift */; };
 		C2E02AE42CF57A5F005F8AB6 /* ArcMoneyCornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E02AE32CF57A5D005F8AB6 /* ArcMoneyCornerRadius.swift */; };
 		C2E6A1282D386C690084E39F /* DropdownRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E6A1272D386C680084E39F /* DropdownRowView.swift */; };
+		C2E6A4392D41BF980084E39F /* DropdownData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E6A4382D41BF970084E39F /* DropdownData.swift */; };
+		C2E6A43B2D41BFB40084E39F /* DropdownDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E6A43A2D41BFB20084E39F /* DropdownDirection.swift */; };
 		C2F839352D2459D50075324E /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F839342D2459D30075324E /* DropdownView.swift */; };
 /* End PBXBuildFile section */
 
@@ -49,6 +51,8 @@
 		C2E02AE12CF57812005F8AB6 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		C2E02AE32CF57A5D005F8AB6 /* ArcMoneyCornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcMoneyCornerRadius.swift; sourceTree = "<group>"; };
 		C2E6A1272D386C680084E39F /* DropdownRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownRowView.swift; sourceTree = "<group>"; };
+		C2E6A4382D41BF970084E39F /* DropdownData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownData.swift; sourceTree = "<group>"; };
+		C2E6A43A2D41BFB20084E39F /* DropdownDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownDirection.swift; sourceTree = "<group>"; };
 		C2F839342D2459D30075324E /* DropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -164,6 +168,8 @@
 		C2E6A1262D386C300084E39F /* DropdownView */ = {
 			isa = PBXGroup;
 			children = (
+				C2E6A4382D41BF970084E39F /* DropdownData.swift */,
+				C2E6A43A2D41BFB20084E39F /* DropdownDirection.swift */,
 				C2E6A1272D386C680084E39F /* DropdownRowView.swift */,
 				C2F839342D2459D30075324E /* DropdownView.swift */,
 			);
@@ -246,6 +252,7 @@
 				C2E6A1282D386C690084E39F /* DropdownRowView.swift in Sources */,
 				C2E02AE22CF57816005F8AB6 /* View+Extensions.swift in Sources */,
 				C226B58E2CD275E900F4BA44 /* ArcMoneyIcon.swift in Sources */,
+				C2E6A4392D41BF980084E39F /* DropdownData.swift in Sources */,
 				C2E02ADF2CF575B8005F8AB6 /* BackgroundedIconView.swift in Sources */,
 				C226B58F2CD275E900F4BA44 /* Colors.swift in Sources */,
 				C201FAEE2D2F222D00592551 /* VStack+Extensions.swift in Sources */,
@@ -257,6 +264,7 @@
 				C2E02AE42CF57A5F005F8AB6 /* ArcMoneyCornerRadius.swift in Sources */,
 				C2E02ADD2CF57516005F8AB6 /* ArcMoneySpacing.swift in Sources */,
 				C25F536D2D0B37E200FB7E86 /* Labels.swift in Sources */,
+				C2E6A43B2D41BFB40084E39F /* DropdownDirection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ArcMoney/Design System/Components/DropdownView/DropdownData.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownData.swift
@@ -1,0 +1,15 @@
+// MARK: - DropdownData
+
+struct DropdownData: Hashable {
+    
+    // MARK: Internal Properties
+    
+    let icon: ArcMoneyIcon
+    let title: String
+    
+    // MARK: Internal Methods
+    
+    static func == (lhs: DropdownData, rhs: DropdownData) -> Bool {
+        lhs.icon == rhs.icon && lhs.title == rhs.title
+    }
+}

--- a/ArcMoney/Design System/Components/DropdownView/DropdownDirection.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownDirection.swift
@@ -1,0 +1,9 @@
+// MARK: - DropdownDirection
+
+enum DropdownDirection {
+    
+    // MARK: Cases
+    
+    case top
+    case bottom
+}

--- a/ArcMoney/Design System/Components/DropdownView/DropdownRowView.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownRowView.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+// MARK: - DropdownRowView
+
+struct DropdownRowView<TrailingContent: View>: View {
+    
+    // MARK: Internal Properties
+    
+    let leadingIcon: ArcMoneyIcon
+    let leadingIconColor: Color
+    let leadingIconBackgroundColor: Color
+    
+    let title: String
+    let backgroundColor: Color
+    let cornerRadius: ArcMoneyCornerRadius
+    
+    let trailingIcon: ArcMoneyIcon?
+    let trailingIconColor: Color?
+    
+    var trailingContent: () -> TrailingContent
+    
+    // MARK: Private Properties
+    
+    /// A helper constant designed to help provide a default placeholder background color for an icon, in case none is specified.
+    /// The default background color will be based on the default `iconColor`.
+    private let defaultBackcolorOpacity = 0.2
+    
+    // MARK: Lifecycle
+    
+    init(
+        leadingIcon: ArcMoneyIcon,
+        leadingIconColor: Color = .primary,
+        leadingIconBackgroundColor: Color? = nil,
+        title: String,
+        backgroundColor: Color = .white,
+        cornerRadius: ArcMoneyCornerRadius = .none,
+        trailingIcon: ArcMoneyIcon? = nil,
+        trailingIconColor: Color = .primary)
+    where TrailingContent == EmptyView {
+        self.init(
+            leadingIcon: leadingIcon,
+            leadingIconColor: leadingIconColor,
+            leadingIconBackgroundColor: leadingIconBackgroundColor,
+            title: title,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            trailingIcon: trailingIcon,
+            trailingIconColor: trailingIconColor,
+            trailingContent: { EmptyView() })
+    }
+    
+    init(
+        leadingIcon: ArcMoneyIcon,
+        leadingIconColor: Color = .primary,
+        leadingIconBackgroundColor: Color? = nil,
+        title: String,
+        backgroundColor: Color = .white,
+        cornerRadius: ArcMoneyCornerRadius = .none,
+        @ViewBuilder trailingContent: @escaping () -> TrailingContent)
+    {
+        self.init(
+            leadingIcon: leadingIcon,
+            leadingIconColor: leadingIconColor,
+            leadingIconBackgroundColor: leadingIconBackgroundColor,
+            title: title,
+            backgroundColor: backgroundColor,
+            cornerRadius: cornerRadius,
+            trailingIcon: nil,
+            trailingIconColor: nil,
+            trailingContent: trailingContent)
+    }
+    
+    private init(
+        leadingIcon: ArcMoneyIcon,
+        leadingIconColor: Color,
+        leadingIconBackgroundColor: Color?,
+        title: String,
+        backgroundColor: Color,
+        cornerRadius: ArcMoneyCornerRadius,
+        trailingIcon: ArcMoneyIcon?,
+        trailingIconColor: Color?,
+        @ViewBuilder trailingContent: @escaping () -> TrailingContent)
+    {
+        self.leadingIcon = leadingIcon
+        self.leadingIconColor = leadingIconColor
+        self.leadingIconBackgroundColor = leadingIconBackgroundColor ?? leadingIconColor.opacity(defaultBackcolorOpacity)
+        
+        self.title = title
+        self.backgroundColor = backgroundColor
+        self.cornerRadius = cornerRadius
+        
+        self.trailingIcon = trailingIcon
+        self.trailingIconColor = trailingIconColor
+        self.trailingContent = trailingContent
+    }
+    
+    // MARK: Body
+    
+    var body: some View {
+        HStack {
+            HStack(spacing: .one){
+                BackgroundedIconView(
+                    icon: leadingIcon,
+                    size: .medium,
+                    color: leadingIconColor,
+                    iconPadding: .one,
+                    backgroundColor: leadingIconBackgroundColor,
+                    cornerRadius: .one)
+                
+                Text(title)
+                    .textStyle(.h2)
+            }
+            
+            Spacer()
+            
+            if let trailingIcon, let trailingIconColor {
+                IconView(
+                    icon: trailingIcon,
+                    size: .medium,
+                    color: trailingIconColor)
+                .padding(.half)
+            } else {
+                trailingContent()
+                    .padding(.half)
+            }
+        }
+        .padding(.half)
+        .background(backgroundColor)
+        .cornerRadius(cornerRadius)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack {
+        DropdownRowView(
+            leadingIcon: .shopping,
+            title: "Shopping",
+            trailingIcon: .dropdownArrow)
+        
+        DropdownRowView(
+            leadingIcon: .shopping,
+            title: "Shopping")
+        
+        DropdownRowView(
+            leadingIcon: .shopping,
+            title: "Shopping",
+            trailingIcon: .checkmark)
+        
+        DropdownRowView(
+            leadingIcon: .education,
+            title: "Trailing Content",
+            trailingContent: {
+                Color.red
+                    .frame(width: 40, height: 40)
+            })
+    }
+    .padding(.oneAndThreeQuarters)
+    .background(.gray)
+}

--- a/ArcMoney/Design System/Components/DropdownView/DropdownRowView.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownRowView.swift
@@ -110,6 +110,7 @@ struct DropdownRowView<TrailingContent: View>: View {
                 Text(title)
                     .textStyle(.h2)
             }
+            .animation(.none, value: UUID()) // Workaround to continue using the deprecated `.animation(.none)` behavior.
             
             Spacer()
             

--- a/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
@@ -7,23 +7,27 @@ struct DropdownView: View {
     // MARK: Internal Properties
 
     @Binding var selection: DropdownData?
-    var options: [DropdownData]
     
+    var options: [DropdownData]
     var dropdownDirection: DropdownDirection = .top
     
     // MARK: Private Properties
     
+    private let maxOptionsHeight: CGFloat
+    private let backgroundColor: Color
+    private let unselectedOption: DropdownData
+    
     @State private var showDropdown = false
     
-    private let backgroundColor: Color = .white
-
-    private let unselectedOption: DropdownData
-        
     // zIndexes are being handled to support multiple DropdownViews being presented in the same View.
     // Without this, multiple menus will overlap themselves if they're opened at the same time.
     // These indexes ensure that the last menu that was opened always stays on top.
     @SceneStorage("drop_down_zindex") private var index = 1000.0
     @State private var zIndex = 1000.0
+    
+    private static let defaultUnselectedOption: DropdownData = .init(
+        icon: .settingsUnselected,
+        title: "Select")
     
     // MARK: Lifecycle
     
@@ -31,11 +35,15 @@ struct DropdownView: View {
         selection: Binding<DropdownData?>,
         options: [DropdownData],
         dropdownDirection: DropdownDirection = .top,
+        maxOptionsHeight: CGFloat = 200,
+        backgroundColor: Color = .white,
         unselectedOption: DropdownData = defaultUnselectedOption)
     {
         self._selection = selection
         self.options = options
         self.dropdownDirection = dropdownDirection
+        self.maxOptionsHeight = maxOptionsHeight
+        self.backgroundColor = backgroundColor
         self.unselectedOption = unselectedOption
     }
     
@@ -115,17 +123,6 @@ struct DropdownView: View {
     }
 }
 
-// MARK: - Default UnselectedOption
-
-extension DropdownView {
-    
-    // MARK: Private Properties
-    
-    private static let defaultUnselectedOption: DropdownData = .init(
-        icon: .settingsUnselected,
-        title: "Select")
-}
-
 // MARK: - Preview
 
 #Preview {
@@ -144,6 +141,13 @@ extension DropdownView {
                 selection: $selection,
                 options: options,
                 dropdownDirection: .bottom)
+            .padding(.oneAndThreeQuarters)
+            .background(.gray)
+            
+            DropdownView(
+                selection: $selection,
+                options: options,
+                dropdownDirection: .top)
             .padding(.oneAndThreeQuarters)
             .background(.gray)
         }

--- a/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
@@ -1,23 +1,13 @@
 import SwiftUI
 
-// MARK: - DropdownDirection
-
-enum DropdownDirection {
-    
-    // MARK: Cases
-    
-    case top
-    case bottom
-}
-
 // MARK: - DropdownView
 
 struct DropdownView: View {
     
     // MARK: Internal Properties
 
-    @Binding var selection: String?
-    var options: [String]
+    @Binding var selection: DropdownData?
+    var options: [DropdownData]
     
     var dropdownDirection: DropdownDirection = .top
     
@@ -26,7 +16,9 @@ struct DropdownView: View {
     @State private var showDropdown = false
     
     private let backgroundColor: Color = .white
-    
+
+    private let unselectedOption: DropdownData
+        
     // zIndexes are being handled to support multiple DropdownViews being presented in the same View.
     // Without this, multiple menus will overlap themselves if they're opened at the same time.
     // These indexes ensure that the last menu that was opened always stays on top.
@@ -35,33 +27,43 @@ struct DropdownView: View {
     
     // MARK: Lifecycle
     
-    init(selection: Binding<String?>, options: [String], dropdownDirection: DropdownDirection = .top) {
+    init(
+        selection: Binding<DropdownData?>,
+        options: [DropdownData],
+        dropdownDirection: DropdownDirection = .top,
+        unselectedOption: DropdownData = defaultUnselectedOption)
+    {
         self._selection = selection
         self.options = options
         self.dropdownDirection = dropdownDirection
+        self.unselectedOption = unselectedOption
     }
     
     // MARK: Internal Methods
     
     func OptionsView() -> some View {
-        VStack(spacing: 0) {
-            ForEach(options, id: \.self) { option in
-                let trailingIcon: ArcMoneyIcon? = (selection == option ? .checkmark : nil)
-                DropdownRowView(
-                    leadingIcon: .shopping,
-                    title: option,
-                    backgroundColor: backgroundColor,
-                    trailingIcon: trailingIcon)
-                .animation(.none, value: selection) // This animation is preventing a bounce animation in the options list
-                .onTapGesture {
-                    withAnimation(.smooth) {
-                        selection = option
-                        showDropdown.toggle()
+        ScrollView(.vertical) {
+            VStack(spacing: 0) {
+                ForEach(options, id: \.self) { option in
+                    let trailingIcon: ArcMoneyIcon? = (selection == option ? .checkmark : nil)
+                    DropdownRowView(
+                        leadingIcon: option.icon,
+                        title: option.title,
+                        backgroundColor: backgroundColor,
+                        trailingIcon: trailingIcon)
+                    .animation(.none, value: selection) // This animation is preventing a bounce animation in the options list
+                    .onTapGesture {
+                        withAnimation(.smooth) {
+                            selection = option
+                            showDropdown.toggle()
+                        }
                     }
                 }
             }
         }
+        .frame(maxHeight: 200)
         .background(backgroundColor)
+        .background(.green)
         .transition(.move(edge: dropdownDirection == .top ? .bottom : .top)) // This transition is making the option list slide from the back of the dropdown instead of fading in
         .zIndex(1)
     }
@@ -78,8 +80,8 @@ struct DropdownView: View {
                 }
                 
                 DropdownRowView(
-                    leadingIcon: .settingsSelected,
-                    title: selection ?? "Select",
+                    leadingIcon: selection?.icon ?? unselectedOption.icon,
+                    title: selection?.title ?? unselectedOption.title,
                     backgroundColor: backgroundColor,
                     trailingContent: {
                         IconView(icon: .dropdownArrow)
@@ -104,24 +106,46 @@ struct DropdownView: View {
             .frame(height: size.height, alignment: dropdownDirection == .top ? .bottom : .top) // The alignment makes the options expand from the view, instead of the view relocate itself to show the options
         }
         .zIndex(zIndex)
+        .onAppear {
+            UIScrollView.appearance().bounces = false
+        }
+        .onDisappear {
+            UIScrollView.appearance().bounces = true
+        }
     }
+}
+
+// MARK: - Default UnselectedOption
+
+extension DropdownView {
+    
+    // MARK: Private Properties
+    
+    private static let defaultUnselectedOption: DropdownData = .init(
+        icon: .settingsUnselected,
+        title: "Select")
 }
 
 // MARK: - Preview
 
 #Preview {
     struct Preview: View {
-        @State var selection: String? = "Option 1"
-        var options: [String] = [
-            "Option 1",
-            "Option 2",
-            "Option 3"
+        @State var selection: DropdownData? = nil
+        var options: [DropdownData] = [
+            .init(icon: .education, title: "Education"),
+            .init(icon: .food, title: "Food"),
+            .init(icon: .entertainment, title: "Entertainment"),
+            .init(icon: .healthcare, title: "Healthcare"),
+            .init(icon: .salary, title: "Salary")
         ]
         
         var body: some View {
-            DropdownView(selection: $selection, options: options, dropdownDirection: .bottom)
-                .padding(.oneAndThreeQuarters)
-                .background(.gray)
+            DropdownView(
+                selection: $selection,
+                options: options,
+                dropdownDirection: .bottom)
+            .padding(.oneAndThreeQuarters)
+            .background(.gray)
         }
     }
     

--- a/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
+++ b/ArcMoney/Design System/Components/DropdownView/DropdownView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+// MARK: - DropdownDirection
+
+enum DropdownDirection {
+    
+    // MARK: Cases
+    
+    case top
+    case bottom
+}
+
+// MARK: - DropdownView
+
+struct DropdownView: View {
+    
+    // MARK: Internal Properties
+
+    @Binding var selection: String?
+    var options: [String]
+    
+    var dropdownDirection: DropdownDirection = .top
+    
+    // MARK: Private Properties
+    
+    @State private var showDropdown = false
+    
+    private let backgroundColor: Color = .white
+    
+    // zIndexes are being handled to support multiple DropdownViews being presented in the same View.
+    // Without this, multiple menus will overlap themselves if they're opened at the same time.
+    // These indexes ensure that the last menu that was opened always stays on top.
+    @SceneStorage("drop_down_zindex") private var index = 1000.0
+    @State private var zIndex = 1000.0
+    
+    // MARK: Lifecycle
+    
+    init(selection: Binding<String?>, options: [String], dropdownDirection: DropdownDirection = .top) {
+        self._selection = selection
+        self.options = options
+        self.dropdownDirection = dropdownDirection
+    }
+    
+    // MARK: Internal Methods
+    
+    func OptionsView() -> some View {
+        VStack(spacing: 0) {
+            ForEach(options, id: \.self) { option in
+                let trailingIcon: ArcMoneyIcon? = (selection == option ? .checkmark : nil)
+                DropdownRowView(
+                    leadingIcon: .shopping,
+                    title: option,
+                    backgroundColor: backgroundColor,
+                    trailingIcon: trailingIcon)
+                .animation(.none, value: selection) // This animation is preventing a bounce animation in the options list
+                .onTapGesture {
+                    withAnimation(.smooth) {
+                        selection = option
+                        showDropdown.toggle()
+                    }
+                }
+            }
+        }
+        .background(backgroundColor)
+        .transition(.move(edge: dropdownDirection == .top ? .bottom : .top)) // This transition is making the option list slide from the back of the dropdown instead of fading in
+        .zIndex(1)
+    }
+    
+    // MARK: Body
+    
+    var body: some View {
+        GeometryReader {
+            let size = $0.size
+            
+            VStack(spacing: 0) {
+                if dropdownDirection == .top && showDropdown {
+                    OptionsView()
+                }
+                
+                DropdownRowView(
+                    leadingIcon: .settingsSelected,
+                    title: selection ?? "Select",
+                    backgroundColor: backgroundColor,
+                    trailingContent: {
+                        IconView(icon: .dropdownArrow)
+                            .padding(.half)
+                            .rotationEffect(.degrees((showDropdown ? -180 : 0)))
+                    })
+                .onTapGesture {
+                    index += 1
+                    zIndex = index
+                    withAnimation(.smooth) {
+                        showDropdown.toggle()
+                    }
+                }
+                .zIndex(10) // The higher zIndex ensures that the selected dropdown option is always in front of the option list. Specially important during the options opening/closing animation
+            
+                if dropdownDirection == .bottom && showDropdown {
+                    OptionsView()
+                }
+            }
+            .clipped() // Prevents the options from expanding outside the dropdown area when its collapsed.
+            .cornerRadius(.one)
+            .frame(height: size.height, alignment: dropdownDirection == .top ? .bottom : .top) // The alignment makes the options expand from the view, instead of the view relocate itself to show the options
+        }
+        .zIndex(zIndex)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct Preview: View {
+        @State var selection: String? = "Option 1"
+        var options: [String] = [
+            "Option 1",
+            "Option 2",
+            "Option 3"
+        ]
+        
+        var body: some View {
+            DropdownView(selection: $selection, options: options, dropdownDirection: .bottom)
+                .padding(.oneAndThreeQuarters)
+                .background(.gray)
+        }
+    }
+    
+    return Preview()
+}

--- a/ArcMoney/Design System/Utils/ArcMoneyIcon.swift
+++ b/ArcMoney/Design System/Utils/ArcMoneyIcon.swift
@@ -21,6 +21,7 @@ enum ArcMoneyIcon: String {
     case settingsUnselected = "gearshape"
     case settingsSelected = "gearshape.fill"
     case dropdownArrow = "chevron.down"
+    case checkmark = "checkmark.circle.fill"
     
     // MARK: Internal Properties
     

--- a/ArcMoney/Design System/Utils/ArcMoneyIcon.swift
+++ b/ArcMoney/Design System/Utils/ArcMoneyIcon.swift
@@ -7,7 +7,7 @@ enum ArcMoneyIcon: String {
     // MARK: Cases
     
     case shopping = "cart.fill"
-    case food = "fork-knife"
+    case food = "fork.knife"
     case entertainment = "popcorn.fill"
     case transportation = "bus"
     case education = "graduationcap.fill"

--- a/ArcMoney/Extensions/HStack+Extensions.swift
+++ b/ArcMoney/Extensions/HStack+Extensions.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+// MARK: - HStack Extensions
+
+extension HStack {
+    
+    // MARK: Init
+    
+    init(alignment: VerticalAlignment = .center, spacing: ArcMoneySpacing, @ViewBuilder content: () -> Content) {
+        self.init(alignment: alignment, spacing: spacing.rawValue, content: content)
+    }
+}

--- a/ArcMoney/Extensions/VStack+Extensions.swift
+++ b/ArcMoney/Extensions/VStack+Extensions.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+// MARK: - VStack Extensions
+
+extension VStack {
+    
+    // MARK: Init
+    
+    init(alignment: HorizontalAlignment = .center, spacing: ArcMoneySpacing, @ViewBuilder content: () -> Content) {
+        self.init(alignment: alignment, spacing: spacing.rawValue, content: content)
+    }
+}


### PR DESCRIPTION
# ArcMoney Pull Request

## Issue
This Pull Request closes #8 

## What changed?
This PR adds `DropdownView` and all its related files. This view provides a customizable dropdown interface based on the project's design system.

`DropdownView` uses auxiliary views called `DropdownRowView`s to provide the interface for the interactable rows of the dropdown.

## Testing
`DropdownView` should be able to
![Screenshot 2025-01-22 at 10 15 29 PM](https://github.com/user-attachments/assets/a7aea90e-1db3-4bed-a9dd-36a61c7583fa)
 be used inside any SwiftUI view, like the preview below:

## Evidence
https://github.com/user-attachments/assets/ccb08f28-b68d-45e8-929d-d87c839a9296